### PR TITLE
Block Access to commands for ignored bots

### DIFF
--- a/javascript-source/systems/pointSystem.js
+++ b/javascript-source/systems/pointSystem.js
@@ -433,7 +433,7 @@
                     // Replace everything that is not \w
                     actionArg1 = $.user.sanitize(actionArg1);
 
-                    if (!$.user.isKnown(actionArg1)) {
+                    if (!$.user.isKnown(actionArg1) || $.isTwitchBot(actionArg1)) {
                         $.say($.whisperPrefix(sender) + $.lang.get('common.user.404', actionArg1));
                         return;
                     }
@@ -469,7 +469,7 @@
                     // Replace everything that is not \w
                     actionArg1 = $.user.sanitize(actionArg1);
 
-                    if (!$.user.isKnown(actionArg1)) {
+                    if (!$.user.isKnown(actionArg1) || $.isTwitchBot(actionArg1)) {
                         $.say($.whisperPrefix(sender) + $.lang.get('common.user.404', actionArg1));
                         return;
                     }
@@ -498,7 +498,7 @@
                     // Replace everything that is not \w
                     actionArg1 = $.user.sanitize(actionArg1);
 
-                    if (!$.user.isKnown(actionArg1)) {
+                    if (!$.user.isKnown(actionArg1) || $.isTwitchBot(actionArg1)) {
                         $.say($.whisperPrefix(sender) + $.lang.get('common.user.404', actionArg1));
                         return;
                     }
@@ -772,7 +772,7 @@
             // Replace everything that is not \w
             action = $.user.sanitize(action);
 
-            if (!$.user.isKnown(action)) {
+            if (!$.user.isKnown(action) || $.isTwitchBot(action)) {
                 $.say($.whisperPrefix(sender) + $.lang.get('pointsystem.gift.404'));
                 return;
             }


### PR DESCRIPTION
This will block !gift !points add, take, give and set from adding removing or setting the points of a ignored bot but this does not stop the beta-panel from doing so

**Before:**
![image goes here](https://i.imgur.com/VHblS4Q.png)

**After:**
![image goes here](https://i.imgur.com/eTLLrl9.png)